### PR TITLE
Complete create a front-end for our web service

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ We set a time constraint of 9 workdays, for shaping, and an additional 9 workday
   - [Sequential job execution with dependency](doc/shape05.md#sequential-job-execution-with-dependency)
   - [Create an access token for Docker Hub](doc/shape05.md#create-an-access-token-for-docker-hub)
 - [ ] [Create a front-end for our web service](doc/shape06.md#create-a-lowdefy-front-end-for-our-web-service) (2)
+  - [Lowdefy Structure](doc/shape06.md#lowdefy-structure)
+  - [Deploy to Netlify](doc/shape06.md#deploy-to-netlify)
+    - [Requirements](doc/shape06.md#requirements)
+    - [Running on a Local Server](doc/shape06.md#running-on-a-local-server)
 - [ ] Expose our web app using Cloudflare Tunnel (1)
 
 This project started on 26-Jan-2022 and is a work-in-progress. The expected completion date is 24-Feb-2022, with an expected shaping completion at 11-Feb-2022 (includes a 2-day cooldown).

--- a/doc/shape06.md
+++ b/doc/shape06.md
@@ -70,12 +70,12 @@ pages:
 ```yml
 id: menu_top
 links:
-  - id: menulink_get_quote
+  - id: menulink_get_status
     type: MenuLink
     properties:
       icon: AlertOutlined
       title: Get quote
-    pageId: page_get_quote
+    pageId: page_get_status
   - id: menulink_welcome
     type: MenuLink
     properties:
@@ -84,7 +84,7 @@ links:
     pageId: page_welcome
 ```
 
-This file exposes two menu links **Get quote** and **Home** with reference ids `menulink_get_quote` and `menulink_welcome`. You can customize each [menu `icon`](https://docs.lowdefy.com/Menu#title) under `properties`.
+This file exposes two menu links **Get quote** and **Home** with reference ids `menulink_get_status` and `menulink_welcome`. You can customize each [menu `icon`](https://docs.lowdefy.com/Menu#title) under `properties`.
 
 3. Create a file `page-get-status.yaml` and add the following code:
 

--- a/doc/shape06.md
+++ b/doc/shape06.md
@@ -5,7 +5,7 @@
 - [Create a Lowdefy front-end for our web service](#create-a-lowdefy-front-end-for-our-web-service)
 - [Constraint](#constraint)
   - [Hill chart](#hill-chart)
-- [User Authentication](#user-authentication)
+- [Lowdefy Structure](#lowdefy-structure)
 - [Deploy to Netlify](#deploy-to-netlify)
   - [Requirements](#requirements)
   - [Running on a Local Server](#running-on-a-local-server)
@@ -18,24 +18,161 @@ Base time: 2 workday (Max: 4)
 
 ## Hill chart
 ```
-  .
+  +
  . .
-+   .
+.   .
 0-1-2
 ```
 
-# User Authentication
+# Lowdefy Structure
 
-To add user authentication and authorization to a Lowdefy app, you need to do the following:
+A **Lowdefy** app is written as YAML files, which are combined together using the `_ref` operator when the app is built, into a configuration object that describes the entire app.
 
-* Configure an **OpenID Connect** provider, such as **Auth0**.
-* Configure which pages should be public and protected.
-* Add the `Login` and `Logout` actions to your app, to allow users to log in and out.
+The root schema for the `lowdefy.yaml` file is:
+
+* `lowdefy: string`: **Required** - The Lowdefy version number the app uses. This is required and cannot be reference to another file.
+* `name: string`: A name for the application.
+* `connections: object[]`: An array of [`connection`](https://docs.lowdefy.com/connections-and-requests) objects.
+* `menus: object[]`: An array of menu objects.
+* `pages: object[]`: An array of page objects.
+
+We will keep each non-trivial objects in separate files, while using the `_ref` operator to reference these files.
+
+* `menu-top.yaml`: An array of menu objects.
+* `page-get-article.yaml`: A page object to get an article.
+* `page-welcome.yaml`: A page object that is created with Lowdefy `init`.
 
 <details>
-    <summary>Click here to <strong>add user authentication</strong></summary>
+    <summary>Click here to <strong>configure the Lowdefy app.</strong></summary>
 
+1. Refactor the root schema. Edit the `lowdefy.yaml` file and replace the code as follows:
 
+```yml
+lowdefy: 3.23.2
+name: archiveso
+
+connections:
+  - id: conn_my_api
+    type: AxiosHttp
+    properties:
+      baseURL: https://dev.to/api
+
+menus:
+  - _ref: menu-top.yaml
+
+pages:
+  - _ref: page-get-quote.yaml
+  - _ref: page-welcome.yaml
+```
+
+2. Create a file `menu-top.yaml` and add the following code:
+
+```yml
+id: menu_top
+links:
+  - id: menulink_get_quote
+    type: MenuLink
+    properties:
+      icon: AlertOutlined
+      title: Get quote
+    pageId: page_get_quote
+  - id: menulink_welcome
+    type: MenuLink
+    properties:
+      icon: HomeOutlined
+      title: Home
+    pageId: page_welcome
+```
+
+This file exposes two menu links **Get quote** and **Home** with reference ids `menulink_get_quote` and `menulink_welcome`. You can customize each [menu `icon`](https://docs.lowdefy.com/Menu#title) under `properties`.
+
+3. Create a file `page-get-status.yaml` and add the following code:
+
+```yml
+id: page_get_status
+type: PageHeaderMenu
+
+requests:
+  - id: http_get_status
+    type: AxiosHttp
+    connectionId: conn_my_api
+    properties:
+      url: /articles?top=1
+
+events:
+  onEnter:
+    - id: event_get_status
+      type: Request
+      params: http_get_status
+
+blocks:
+  - id: md_rest_data
+    type: Markdown
+    properties:
+      content:
+        _string.concat:
+          - |
+            ```yaml
+          - _yaml.stringify:
+              - _log:
+                  _request: http_get_status
+          - |
+            ```
+```
+
+We reference the connection object that we created in the `lowdefy.yaml` file using the `connectionId`. The request get executed on page enter, and it converts the payload from JSON to YAML format.
+
+4. Create a file `page-welcome.yaml` and add the following code:
+
+```yml
+id: page_welcome
+type: PageHeaderMenu
+properties:
+  title: Welcome
+areas:
+  content:
+    justify: center
+    blocks:
+      - id: content_card
+        type: Card
+        style:
+          maxWidth: 800
+        blocks:
+          - id: content
+            type: Result
+            properties:
+              title: Welcome to your Lowdefy app
+              subTitle: We are excited to see what you are going to build
+              icon:
+                name: HeartTwoTone
+                color: '#f00'
+            areas:
+              extra:
+                blocks:
+                  - id: docs_button
+                    type: Button
+                    properties:
+                      size: large
+                      title: Let's build something
+                      color: '#1890ff'
+                    events:
+                      onClick:
+                        - id: link_to_docs
+                          type: Link
+                          params:
+                            url: https://docs.lowdefy.com
+                            newTab: true
+  footer:
+    blocks:
+      - id: footer
+        type: Paragraph
+        properties:
+          type: secondary
+          content: |
+            Made by a Lowdefy 🤖
+```
+
+This page is taken from the default `lowdefy.yaml` file, after we executed the `init` command.
 
 </details>
 
@@ -74,7 +211,7 @@ If your repository isn't found, click "**Configure Netlify on Github**", and giv
 Configure your Netlify deployment.
 
 * Set your base directory to `front`.
-* Set your build command to `npx lowdefy@3 build-netlify`.
+* Set your build command to `npx lowdefy@latest build-netlify`.
 * Set your publish directory to `front/.lowdefy/publish`.
 
 **Step 4**
@@ -82,7 +219,7 @@ Configure your Netlify deployment.
 Configure the Lowdefy server.
 
 * Click the "**Advanced build settings**" button.
-* Set the functions directory to `front/.lowdefy/functions`.
+* Set the functions directory to `.lowdefy/functions`.
 
 **Step 5**
 

--- a/front/lowdefy.yaml
+++ b/front/lowdefy.yaml
@@ -1,51 +1,15 @@
-
 lowdefy: 3.23.2
-name: Lowdefy starter
+name: archiveso
+
+connections:
+  - id: conn_my_api
+    type: AxiosHttp
+    properties:
+      baseURL: https://dev.to/api
+
+menus:
+  - _ref: menu-top.yaml
 
 pages:
-  - id: welcome
-    type: PageHeaderMenu
-    properties:
-      title: Welcome
-    areas:
-      content:
-        justify: center
-        blocks:
-          - id: content_card
-            type: Card
-            style:
-              maxWidth: 800
-            blocks:
-              - id: content
-                type: Result
-                properties:
-                  title: Welcome to your Lowdefy app
-                  subTitle: We are excited to see what you are going to build
-                  icon:
-                    name: HeartTwoTone
-                    color: '#f00'
-                areas:
-                  extra:
-                    blocks:
-                      - id: docs_button
-                        type: Button
-                        properties:
-                          size: large
-                          title: Let's build something
-                          color: '#1890ff'
-                        events:
-                          onClick:
-                            - id: link_to_docs
-                              type: Link
-                              params:
-                                url: https://docs.lowdefy.com
-                                newTab: true
-      footer:
-        blocks:
-          - id: footer
-            type: Paragraph
-            properties:
-              type: secondary
-              content: |
-                Made by a Lowdefy 🤖
-
+  - _ref: page-get-quote.yaml
+  - _ref: page-welcome.yaml

--- a/front/menu-top.yaml
+++ b/front/menu-top.yaml
@@ -1,11 +1,11 @@
 id: menu_top
 links:
-  - id: menulink_get_quote
+  - id: menulink_get_status
     type: MenuLink
     properties:
       icon: AlertOutlined
       title: Get quote
-    pageId: page_get_quote
+    pageId: page_get_status
   - id: menulink_welcome
     type: MenuLink
     properties:

--- a/front/menu-top.yaml
+++ b/front/menu-top.yaml
@@ -1,0 +1,14 @@
+id: menu_top
+links:
+  - id: menulink_get_quote
+    type: MenuLink
+    properties:
+      icon: AlertOutlined
+      title: Get quote
+    pageId: page_get_quote
+  - id: menulink_welcome
+    type: MenuLink
+    properties:
+      icon: HomeOutlined
+      title: Home
+    pageId: page_welcome

--- a/front/page-get-status.yaml
+++ b/front/page-get-status.yaml
@@ -1,0 +1,29 @@
+id: page_get_status
+type: PageHeaderMenu
+
+requests:
+  - id: http_get_status
+    type: AxiosHttp
+    connectionId: conn_my_api
+    properties:
+      url: /articles?top=1
+
+events:
+  onEnter:
+    - id: event_get_status
+      type: Request
+      params: http_get_status
+
+blocks:
+  - id: md_rest_data
+    type: Markdown
+    properties:
+      content:
+        _string.concat:
+          - |
+            ```yaml
+          - _yaml.stringify:
+              - _log:
+                  _request: http_get_status
+          - |
+            ```

--- a/front/page-welcome.yaml
+++ b/front/page-welcome.yaml
@@ -1,0 +1,45 @@
+id: page_welcome
+type: PageHeaderMenu
+properties:
+  title: Welcome
+areas:
+  content:
+    justify: center
+    blocks:
+      - id: content_card
+        type: Card
+        style:
+          maxWidth: 800
+        blocks:
+          - id: content
+            type: Result
+            properties:
+              title: Welcome to your Lowdefy app
+              subTitle: We are excited to see what you are going to build
+              icon:
+                name: HeartTwoTone
+                color: '#f00'
+            areas:
+              extra:
+                blocks:
+                  - id: docs_button
+                    type: Button
+                    properties:
+                      size: large
+                      title: Let's build something
+                      color: '#1890ff'
+                    events:
+                      onClick:
+                        - id: link_to_docs
+                          type: Link
+                          params:
+                            url: https://docs.lowdefy.com
+                            newTab: true
+  footer:
+    blocks:
+      - id: footer
+        type: Paragraph
+        properties:
+          type: secondary
+          content: |
+            Made by a Lowdefy 🤖


### PR DESCRIPTION
Complete create a front-end for our web service.

This is part 6 of 7 parts of the end-to-end application that includes a
CI pipeline.

We keep our root schema for the `lowdefy.yaml` file lean, by separating
each non-trivial Lowdefy object into its own file, , while using the
_ref operator to reference these files.

We have two menu links **Get status** and **Home**, the former gets the
status from an API connection, and the latter goes to the default
Lowdefy home page.

Next part is to expose our web app using Cloudflare Tunnel.