### PR TITLE
Complete expose our web app using cloudflared

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,13 @@ This project is an end-to-end application, using the Shape Up metholodogy, that 
 
 - [archiveso](#archiveso)
 - [Things to learn and research](#things-to-learn-and-research)
+- [Place, Affordance, Connection](#place-affordance-connection)
 - [Shaping](#shaping)
 - [Building](#building)
+- [Limitation](#limitation)
 - [Methodology](#methodology)
 - [Project Structure](#project-structure)
+- [Troubleshooting](#troubleshooting)
 - [Reference](#reference)
 
 <!-- /TOC -->
@@ -33,6 +36,16 @@ In no particular order, my plan is to use the following resources to learn and r
 | E-Book: Shape Up | Ryan Singer | Basecamp 2021 [Sing2021]
 | [Lowdefy Documentation](https://docs.lowdefy.com/introduction) | Lowdefy | 2022 [Lowd2022]
 | [Python API Usage - ArchiveBox Documentation](https://docs.archivebox.io/en/latest/Usage.html#python-api-usage) | ArchiveBox | 2022 [Arch2022]
+
+# Place, Affordance, Connection
+
+* Places users can navigate
+  * Lowdefy app e.g. `https://archiveso.netlify.app`
+  * Python Flask server (with cloudflared as a service) e.g. `https://archiveso.markit.work` 
+  * Docker Hub e.g. `https://hub.docker.com/repository/docker/dennislwm/archiveso`
+  
+* Affordance users can act
+  * Docker pull `docker pull dennislwm/archiveso:latest`
 
 ---
 # Shaping
@@ -61,17 +74,27 @@ We set a time constraint of 9 workdays, for shaping, and an additional 9 workday
   - [Workflows](doc/shape05.md#workflows)
   - [Sequential job execution with dependency](doc/shape05.md#sequential-job-execution-with-dependency)
   - [Create an access token for Docker Hub](doc/shape05.md#create-an-access-token-for-docker-hub)
-- [ ] [Create a front-end for our web service](doc/shape06.md#create-a-lowdefy-front-end-for-our-web-service) (2)
+- [X] [Create a front-end for our web service](doc/shape06.md#create-a-lowdefy-front-end-for-our-web-service) (2)
   - [Lowdefy Structure](doc/shape06.md#lowdefy-structure)
   - [Deploy to Netlify](doc/shape06.md#deploy-to-netlify)
     - [Requirements](doc/shape06.md#requirements)
     - [Running on a Local Server](doc/shape06.md#running-on-a-local-server)
-- [ ] Expose our web app using Cloudflare Tunnel (1)
+- [X] [Expose our web app using Cloudflare Tunnel](doc/shape07.md#expose-our-web-app-using-cloudflare-tunnel) (1)
+  - [Prerequisites](doc/shape07.md#prerequisites)
+  - [Deploy container on local workstation](doc/shape07.md#deploy-container-on-local-workstation)
+  - [Set up cloudflared](doc/shape07.md#set-up-cloudflared)
+  - [Run cloudflared](doc/shape07.md#run-cloudflared)
 
-This project started on 26-Jan-2022 and is a work-in-progress. The expected completion date is 24-Feb-2022, with an expected shaping completion at 11-Feb-2022 (includes a 2-day cooldown).
+This project started on 26-Jan-2022 and the shaping cycle was completed on 8-Feb-2022 (8 days). The expected completion date for building is 24-Feb-2022, which includes a 2-day cooldown period.
 
 ---
 # Building
+
+---
+# Limitation
+
+* The CI pipeline does not perform the last mile delivery, i.e deploy the Docker container Python Flask server app after it has been tagged and pushed to Docker Hub. The Continuous Delivery ["CD"] pipeline is not implemented. 
+* Currently, I'm hosting the Docker container on my local workstation, i.e. http://localhost:8080 and using Cloud Tunnel to access it via https://archiveso.mydomain.com.
 
 ---
 # Methodology
@@ -110,6 +133,18 @@ root
    +- test/
 +- .circleci/                                 <-- Holds CircleCI files
    |- config.yml                              <-- Config file for CI pipeline implementation
++- front/                                     <-- Holds Lowdefy front-end static files
+   |- lowdefy.yaml                            <-- YAML file for Lowdefy root schema
+```
+
+# Troubleshooting
+
+1. Argo Tunnel error
+
+Your cloudflared tunnel is not running as a service.
+
+```sh
+cloudflared tunnel --config ~/.cloudflared/config-archiveso.yml run
 ```
 
 # Reference

--- a/doc/shape05.md
+++ b/doc/shape05.md
@@ -5,6 +5,7 @@
 - [Build, test, tag and upload our web app image using CI](#build-test-tag-and-upload-our-web-app-image-using-ci)
 - [Constraint](#constraint)
   - [Hill chart](#hill-chart)
+- [Place, Affordance, Connection](#place-affordance-connection)
 - [Workflows](#workflows)
 - [Sequential job execution with dependency](#sequential-job-execution-with-dependency)
 - [Create an access token for Docker Hub](#create-an-access-token-for-docker-hub)
@@ -21,6 +22,14 @@ Base time: 1 workday (Max: 2)
 . +
 0-1
 ```
+
+# Place, Affordance, Connection
+
+* Places users can navigate
+  * Docker Hub e.g. `https://hub.docker.com/repository/docker/dennislwm/archiveso`
+  
+* Affordance users can act
+  * Docker pull `docker pull dennislwm/archiveso:latest`
 
 # Workflows
 

--- a/doc/shape06.md
+++ b/doc/shape06.md
@@ -5,6 +5,7 @@
 - [Create a Lowdefy front-end for our web service](#create-a-lowdefy-front-end-for-our-web-service)
 - [Constraint](#constraint)
   - [Hill chart](#hill-chart)
+- [Place, Affordance, Connection](#place-affordance-connection)
 - [Lowdefy Structure](#lowdefy-structure)
 - [Deploy to Netlify](#deploy-to-netlify)
   - [Requirements](#requirements)
@@ -23,6 +24,16 @@ Base time: 2 workday (Max: 4)
 .   .
 0-1-2
 ```
+
+# Place, Affordance, Connection
+
+* Places users can navigate
+  * Lowdefy app e.g. `https://archiveso.netlify.app`
+    * Get status `/page_get_status`
+    * Home `/page_welcome`
+
+* Connection users are taken to
+  * Get status --> Lowdefy --> `/page_get_status` --> Docker --> `main.py` --> HTTP response
 
 # Lowdefy Structure
 

--- a/doc/shape07.md
+++ b/doc/shape07.md
@@ -1,0 +1,166 @@
+# Expose our web app using Cloudflare Tunnel
+
+<!-- TOC -->
+
+- [Expose our web app using Cloudflare Tunnel](#expose-our-web-app-using-cloudflare-tunnel)
+- [Constraint](#constraint)
+  - [Hill chart](#hill-chart)
+- [Place, Affordance, Connection](#place-affordance-connection)
+- [Prerequisites](#prerequisites)
+- [Deploy container on local workstation](#deploy-container-on-local-workstation)
+- [Set up cloudflared](#set-up-cloudflared)
+- [Run cloudflared](#run-cloudflared)
+
+<!-- /TOC -->
+
+# Constraint
+
+Base time: 1 workday (Max: 2)
+
+## Hill chart
+```
+ +
+. .
+0-1
+```
+
+# Place, Affordance, Connection
+
+* Places users can navigate
+  * Cloudflare tunnel to Python Flask server e.g. `https://archiveso.mydomain.com`
+    * Status endpoint `/`
+    * Application endpoint `/api/archiveso`
+
+* Affordance users can act
+  * Test `GET https://archiveso.mydomain.com/` returns HTTP Status `200` and payload `App-version: *`
+  * Test `GET https://archiveso.mydomain.com/api/archiveso` returns HTTP Status `200`.
+
+* Connection users are taken to
+  * `GET https://archiveso.mydomain.com/` --> cloudflared --> Docker --> `main.py` --> HTTP response
+  * `GET https://archiveso.mydomain.com/api/archiveso` --> cloudflared --> Docker --> `main.py` --> `clsArchiveso.py` --> `/path/to/archivebox` --> `archivebox.cli.list()` --> String --> HTTP response
+
+# Prerequisites
+
+* [Cloudflare free account](https://cloudflare.com)
+* [Cloudflare CLI](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/tunnel-guide)
+* [Domain name with Cloudflare DNS](https://support.cloudflare.com/hc/en-us/articles/205195708-Changing-your-domain-nameservers-to-Cloudflare)
+
+# Deploy container on local workstation
+
+Currently, I'm hosting the Docker container Python Flask server app on my local workstation, i.e. http://localhost:8080 and using Cloud Tunnel to access it via https://archiveso.mydomain.com.
+
+Deploy the Docker container on your local workstation. This command pulls the image from Docker Hub if it doesn't exist.
+
+```sh
+docker run -p 8080:8080 -d --rm --name objArchiveso dennislwm/archiveso:latest
+```
+
+# Set up cloudflared
+
+<details>
+    <summary>Click here to <strong>set up cloudflared.</strong></summary>
+
+1. Run the following command to authenticate your cloudflare account:
+
+```sh
+cloudflared tunnel login
+```
+
+This will create a certificate file `cert.pem` with your credentials in the path `~/.cloudflared`.
+
+2. Create a tunnel
+
+```sh
+cloudflared tunnel create TUNNELNAME
+```
+
+This creates a UUID that is associated with the TUNNELNAME that you gave. At this point, no connection is active within the tunnel yet.
+
+Verify that the TUNNELNAME has been created successfully.
+
+```sh
+cloudflared tunnel list
+You can obtain more detailed information for each tunnel with `cloudflared tunnel info <name/uuid>`
+ID                                   NAME              CREATED              CONNECTIONS 
+6ff70722-7854-454d-aeec-793674227b0d archiveso         2022-02-08T02:36:22Z             
+```
+
+3. Create a configuration file
+
+Create a `config.yml` file in the path `~/.cloudflared/` and add the following lines:
+
+```yml
+tunnel: 6ff70722-7854-454d-aeec-793674227b0d
+credentials-file: /Users/dennislwm/.cloudflared/6ff70722-7854-454d-aeec-793674227b0d.json
+warp-routing:
+  enabled: true
+```
+
+4. Assign a CNAME record
+
+Now assign a CNAME record that points traffic to your subdomain.
+
+```sh
+cloudflared tunnel route dns TUNNELNAME archiveso.mydomain.com
+```
+
+5. Reference a configuration file
+
+When running a tunnel, make sure you specify the path to your configuration file.
+
+```sh
+cloudflared tunnel --config ~/.cloudflared/config.yml run
+2022-02-08T02:57:49Z INF Starting tunnel tunnelID=6ff70722-7854-454d-aeec-793674227b0d
+2022-02-08T02:57:49Z INF Version 2022.1.2
+2022-02-08T02:57:49Z INF GOOS: darwin, GOVersion: go1.17.2, GoArch: amd64
+2022-02-08T02:57:49Z INF Settings: map[config:/Users/dennislwm/.cloudflared/config-archiveso.yml cred-file:/Users/dennislwm/.cloudflared/6ff70722-7854-454d-aeec-793674227b0d.json credentials-file:/Users/dennislwm/.cloudflared/6ff70722-7854-454d-aeec-793674227b0d.json url:http://localhost:8080]
+2022-02-08T02:57:49Z INF cloudflared will not automatically update when run from the shell. To enable auto-updates, run cloudflared as a service: https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/run-tunnel/run-as-service
+2022-02-08T02:57:49Z INF Generated Connector ID: 36295d2e-f14e-498e-adf0-cdf6eaacddf8
+2022-02-08T02:57:49Z INF Warp-routing is enabled
+2022-02-08T02:57:49Z INF Initial protocol http2
+2022-02-08T02:57:49Z INF Starting metrics server on 127.0.0.1:64231/metrics
+2022-02-08T02:57:49Z WRN Your version 2022.1.2 is outdated. We recommend upgrading it to 2022.2.0
+2022-02-08T02:57:50Z INF Connection 936af740-d529-41ab-a031-bdf8cc98d700 registered connIndex=0 location=SIN
+2022-02-08T02:57:51Z INF Connection 86654f02-25ca-4670-a2b3-e9ea7c9cb6fc registered connIndex=1 location=HKG
+2022-02-08T02:57:52Z INF Connection 8879ab6d-91f5-497a-978b-827dbb7ab94a registered connIndex=2 location=SIN
+2022-02-08T02:57:53Z INF Connection 4eb02cf6-d584-4407-aea9-0fa68647bebe registered connIndex=3 location=HKG
+```
+
+Verify that the tunnel is complete.
+
+```sh
+cloudflared tunnel info TUNNELNAME
+```
+
+</details>
+
+# Run cloudflared
+
+When you run cloudflared tunnel, it remains as a foreground service. However, you can choose to run it as a [service](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/run-tunnel/run-as-service).
+
+```sh
+cloudflared tunnel --config ~/.cloudflared/config-archiveso.yml run
+```
+
+Navigate to [Lowdefy app](https://archiveso.netlify.app/page_get_status) and you should see the following:
+
+```yml
+data: 'App-version: 0.1.0'
+headers:
+  alt-svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400
+  cf-cache-status: DYNAMIC
+  cf-ray: 6da1b1b8ad718968-SIN
+  connection: close
+  content-type: text/html; charset=utf-8
+  date: Tue, 08 Feb 2022 03:15:33 GMT
+  expect-ct: >-
+    max-age=604800,
+    report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+  nel: '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+  report-to: >-
+    {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=lPy8uGW1LdlVG2x13WLRsea%2Bx%2BrFxmk7qiQIuI9PzrmqLjc1lVTPoDYAEhCd014Ech858aOoGwZTGfBOI0S0Ytokb5jlRlwIyTr4lEuG9lLDmU6JMP%2Fx7FYMnx6RrBxzYOEd1SIU3GM%3D"}],"group":"cf-nel","max_age":604800}
+  server: cloudflare
+  transfer-encoding: chunked
+status: 200
+statusText: OK
+```

--- a/front/lowdefy.yaml
+++ b/front/lowdefy.yaml
@@ -5,7 +5,7 @@ connections:
   - id: conn_my_api
     type: AxiosHttp
     properties:
-      baseURL: https://dev.to/api
+      baseURL: https://archiveso.markit.work
 
 menus:
   - _ref: menu-top.yaml

--- a/front/page-get-status.yaml
+++ b/front/page-get-status.yaml
@@ -6,7 +6,7 @@ requests:
     type: AxiosHttp
     connectionId: conn_my_api
     properties:
-      url: /articles?top=1
+      url: /
 
 events:
   onEnter:


### PR DESCRIPTION
This is part 7 of 7 parts of the end-to-end application that includes a
CI pipeline.

Currently, I'm hosting the Docker container Python Flask server app on
my local workstation, i.e. http://localhost:8080 and using cloudflared
as a service to access at https://archiveso.markit.work.

Next part is the cooldown period followed by the building cycle.