### PR TITLE
Complete Python Flask server authentication.

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,12 @@ This project started on 26-Jan-2022 and the shaping cycle was completed on 8-Feb
   - [Create a MongoDB cluster](doc/build01.md#create-a-mongodb-cluster)
   - [Create an Auth0 OpenID Connect provider](doc/build01.md#create-an-auth0-openid-connect-provider)
   - [Secure the Auth0 connections](doc/build01.md#secure-the-auth0-connections)
-- [ ] Python Flask server tokenization (1)
+- [X] [Python Flask server authentication](doc/build02.md#python-flask-server-authentication) (1)
+  - [HTTP Basic Authentication](doc/build02.md#http-basic-authentication)
+  - [Requirements](doc/build02.md#requirements)
+  - [Set up authorization in the Lowdefy app](doc/build02.md#set-up-authorization-in-the-lowdefy-app)
+  - [Protect the Python Flask server routes with HTTP Basic authentication](doc/build02.md#protect-the-python-flask-server-routes-with-http-basic-authentication)
+  - [Retrieve secrets during test and run](doc/build02.md#retrieve-secrets-during-test-and-run)
 
 This steps are repeatable, i.e. expose an endpoint and build a page to allow user interaction.
 - [ ] Build a Lowdefy page to allow user interaction (1)
@@ -231,3 +236,8 @@ The following resources were used as a single-use reference.
 | [Build and Deploy only on PR request Accept](https://discuss.circleci.com/t/build-and-deploy-only-on-pr-request-accept/38846) | CircleCI | 2021 [Circ2021]
 | [Using CircleCI workflows to replicate Docker Hub automated builds](https://circleci.com/blog/using-circleci-workflows-to-replicate-docker-hub-automated-builds/) | Jonathan Cardoso | 2020 [Card2020]
 | GitHub Repo: [lowdefy-example-openid-connect](https://github.com/lowdefy/lowdefy-example-openid-connect) | lowdefy | 2021 [Lowd2021]
+| [Developing RESTful APIs with Python and Flask](https://auth0.com/blog/developing-restful-apis-with-python-and-flask/) | Bruno Krebs | 2021 [Kreb2021]
+| [Building a RESTful Blog APIs using python and flask - Part 2](https://www.codementor.io/@olawalealadeusi896/building-a-restful-blog-apis-using-python-and-flask-part-2-l9y8awusp) | Olawale Aladeusi | 2018 [Alad2018]
+| [How to Handle JWTs in Python](https://auth0.com/blog/how-to-handle-jwt-in-python/) | Jessica Temporal | 2021 [Temp2021]
+| [Flask-HTTPAuth documentation](https://flask-httpauth.readthedocs.io/en/latest/) | Miguel Grinberg | 2022 [Grin2022]
+| [Docker ARG, ENV and .env - a Complete Guide](https://vsupalov.com/docker-arg-env-variable-guide/) | Vladislav Supalov | 2022 [Supa2022]

--- a/app/.dockerignore
+++ b/app/.dockerignore
@@ -1,0 +1,9 @@
+.dockerignore
+.DS_Store
+.env
+.git
+.gitignore
+.pytest_cache
+docker-compose.yml
+Makefile
+Pipfile*

--- a/app/Makefile
+++ b/app/Makefile
@@ -9,10 +9,10 @@ docker_clean:
 	docker image prune -f
 
 docker_run: docker_build docker_clean
-	docker run --rm -d -p 80:8080 --name=objArchiveso archiveso
+	docker run --rm -d -p 8080:8080 --env-file=../front/.env --name=objArchiveso archiveso
 
 docker_prod: docker_stop
-	docker run -p 8080:8080 -d --rm --name objArchiveso dennislwm/archiveso:latest
+	docker run --rm -d -p 8080:8080 --env-file=../front/.env --name objArchiveso dennislwm/archiveso:latest
 
 docker_stop:
 	docker container stop objArchiveso
@@ -23,7 +23,10 @@ docker_tunnel:
 front_build:
 	cd ../front/ && npx lowdefy@latest build
 
-front_dev: docker_prod front_build
+front_dev: docker_run front_build
+	cd ../front/ && npx lowdefy@latest dev
+
+front_prod: docker_prod front_build
 	cd ../front/ && npx lowdefy@latest dev
 
 install_freeze:
@@ -33,14 +36,14 @@ install_freeze:
 	pip3 uninstall -y pipreqs
 	
 install_new: 
-	pipenv install archivebox==0.6.2 flask==1.0.2
+	pipenv install archivebox==0.6.2 flask==1.0.2 flask_httpauth==4.5.0 Werkzeug==2.0.2
 	pipenv install --dev pytest==6.2.4 pytest-flask==1.2.0
 
 install_pipfile:
 	pipenv install --dev
 
 run: 
-	FLASK_ENV=development FLASK_APP=main PYTHONPATH=./:./src/archiveso python3 -m flask run --host=0.0.0.0 --port=8080
+	set -a && source ../front/.env && set +a && FLASK_ENV=development FLASK_APP=main PYTHONPATH=./:./src/archiveso python3 -m flask run --host=0.0.0.0 --port=8080
 
 shell:
 	pipenv shell

--- a/app/Pipfile
+++ b/app/Pipfile
@@ -6,6 +6,8 @@ name = "pypi"
 [packages]
 archivebox = "==0.6.2"
 flask = "==1.0.2"
+flask-httpauth = "==4.5.0"
+werkzeug = "==2.0.2"
 
 [dev-packages]
 pytest = "==6.2.4"

--- a/app/Pipfile.lock
+++ b/app/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8499638318e89fec3cadc449e9069e609e5e7fb30b39abf11cb19f3256d5c0fd"
+            "sha256": "e4f922d66ce18ae7f3061c558ce5cb44f7e720beac572be22f130f9d1a0da454"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -160,6 +160,14 @@
             ],
             "index": "pypi",
             "version": "==1.0.2"
+        },
+        "flask-httpauth": {
+            "hashes": [
+                "sha256:395040fda2854df800d15e84bc4a81a5f32f1d4a5e91eee554936f36f330aa29",
+                "sha256:e16067ba3378ea366edf8de4b9d55f38c0a0cbddefcc0f777a54b3fce1d99392"
+            ],
+            "index": "pypi",
+            "version": "==4.5.0"
         },
         "idna": {
             "hashes": [
@@ -323,19 +331,19 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:1d7385c7db91728b83efd0ca99a5afb296cab9d0ed8313a45ed8ba17967ecfca",
-                "sha256:440633ddfebcc36264232365d7840a970e75e1018d15b4327d11f91909045fda"
+                "sha256:30671902352e97b1eafd74ade8e4a694782bd3471685e78c32d0fdfd3aa7e7bb",
+                "sha256:8ec11dfba28ecc0715eb5fb0147a87b1bf325f349f3da9aab2cd6b50b96b692b"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.4.1"
+            "version": "==2.5.0"
         },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:4bcf119be2200c17ed0d518872ef922f1de336eb6d1ddbd1e089ceb6447d97c6",
-                "sha256:a51d41a6a45fd9def54365bca8f0402c8f182f2b6f7e29c74d55faeb9fb38ac4"
+                "sha256:cb7dae7d2c59188c85a1d6c944fad19aded6a26bd9c8ae115a4e1c20eb90b713",
+                "sha256:f2b6a8067a4fb959d3677d1ed764cc4e63e0f6f565b9a4fc7edc2b18bf80217b"
             ],
             "markers": "python_full_version >= '3.6.2'",
-            "version": "==3.0.26"
+            "version": "==3.0.27"
         },
         "ptyprocess": {
             "hashes": [
@@ -477,11 +485,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:a4dc3af29a67e7a45620aba43dde2c1af2dd6bc49726d78168f0cc6c4fb0c01b",
-                "sha256:c9097cbcdefe88a64da966a764f2d95feb1cfaff77cc304528a23cefe3359d9a"
+                "sha256:43a5575eea6d3459789316e1596a3d2a0d215260cacf4189508112f35c9a145b",
+                "sha256:66b8598da112b8dc8cd941d54cf63ef91d3b50657b374457eda5851f3ff6a899"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==60.7.1"
+            "version": "==60.8.2"
         },
         "six": {
             "hashes": [
@@ -508,11 +516,11 @@
         },
         "tomli": {
             "hashes": [
-                "sha256:b5bde28da1fed24b9bd1d4d2b8cba62300bfb4ec9a6187a957e8ddb9434c5224",
-                "sha256:c292c34f58502a1eb2bbb9f5bbc9a5ebc37bee10ffb8c2d6bbdfa8eb13cc14e1"
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.0.0"
+            "version": "==2.0.1"
         },
         "traitlets": {
             "hashes": [
@@ -573,7 +581,7 @@
                 "sha256:63d3dc1cf60e7b7e35e97fa9861f7397283b75d765afcaefd993d6046899de8f",
                 "sha256:aa2bb6fc8dee8d6c504c0ac1e7f5f7dc5810a9903e793b6f715a9f015bdadb9a"
             ],
-            "markers": "python_version >= '3.6'",
+            "index": "pypi",
             "version": "==2.0.2"
         },
         "youtube-dl": {
@@ -768,7 +776,7 @@
                 "sha256:63d3dc1cf60e7b7e35e97fa9861f7397283b75d765afcaefd993d6046899de8f",
                 "sha256:aa2bb6fc8dee8d6c504c0ac1e7f5f7dc5810a9903e793b6f715a9f015bdadb9a"
             ],
-            "markers": "python_version >= '3.6'",
+            "index": "pypi",
             "version": "==2.0.2"
         }
     }

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -4,4 +4,7 @@ services:
   # Pipeline actions
   archiveso:
     image: archiveso:latest
+      environment:
+        - LOWDEFY_SECRET_API_USERNAME
+        - LOWDEFY_SECRET_API_PASSWORD
     entrypoint: /usr/local/bin/prospector

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   # Pipeline actions
   archiveso:
     image: archiveso:latest
-      environment:
-        - LOWDEFY_SECRET_API_USERNAME
-        - LOWDEFY_SECRET_API_PASSWORD
+    environment:
+      - LOWDEFY_SECRET_API_USERNAME
+      - LOWDEFY_SECRET_API_PASSWORD
     entrypoint: /usr/local/bin/prospector

--- a/app/main.py
+++ b/app/main.py
@@ -1,11 +1,30 @@
+import os
+
 from flask import Flask
+from flask_httpauth import HTTPBasicAuth
+from werkzeug.security import generate_password_hash, check_password_hash
 
 def create_app():
     app = Flask(__name__)
+    auth = HTTPBasicAuth()
+
+    API_USERNAME = os.getenv('LOWDEFY_SECRET_API_USERNAME', '')
+    API_PASSWORD = os.getenv('LOWDEFY_SECRET_API_PASSWORD', '')
+
+    users = {
+        API_USERNAME: generate_password_hash(API_PASSWORD),
+    }
+
+    @auth.verify_password
+    def verify_password(username, password):
+        if username in users:
+            return check_password_hash(users.get(username), password)
+        return False
 
     @app.route("/")
+    @auth.login_required
     def root():
-        return "App-version: 0.1.0"
+        return "App-version: 0.2.0"
 
     return app
 

--- a/doc/build02.md
+++ b/doc/build02.md
@@ -134,8 +134,8 @@ The `docker-compose.yml` file accepts the environment variables from the host, w
 services:
   archiveso:
     image: archiveso:latest
-      environment:
-        - LOWDEFY_SECRET_API_USERNAME
-        - LOWDEFY_SECRET_API_PASSWORD
+    environment:
+      - LOWDEFY_SECRET_API_USERNAME
+      - LOWDEFY_SECRET_API_PASSWORD
       ...
 ```

--- a/doc/build02.md
+++ b/doc/build02.md
@@ -1,0 +1,141 @@
+# Python Flask server authentication
+
+<!-- TOC -->
+
+- [Python Flask server authentication](#python-flask-server-authentication)
+- [Constraint](#constraint)
+  - [Hill chart](#hill-chart)
+- [HTTP Basic Authentication](#http-basic-authentication)
+- [Requirements](#requirements)
+- [Set up authorization in the Lowdefy app](#set-up-authorization-in-the-lowdefy-app)
+- [Protect the Python Flask server routes with HTTP Basic authentication](#protect-the-python-flask-server-routes-with-http-basic-authentication)
+- [Retrieve secrets during test and run](#retrieve-secrets-during-test-and-run)
+
+<!-- /TOC -->
+
+# Constraint
+
+Base time: 1 workday (Max: 2)
+
+## Hill chart
+```
+ .
+. +
+0-1
+```
+
+# HTTP Basic Authentication
+
+We are using HTTP basic authentication for our Python Flask server. This is to prevent any unauthorized persons to access our API endpoints, which are available via a public domain.
+
+# Requirements
+
+* [Flask-HTTPAuth](https://flask-httpauth.readthedocs.io/en/latest/)
+
+# Set up authorization in the Lowdefy app
+
+The Lowdefy **Secrets** object is an object that can be used to securely store sensitive information. Secrets can be accessed using the `_secret` operator.
+
+The secrets object only exists on the backend server, and therefore the `_secret` operator can only be used in `connections` and `requests`. Secrets can only be set with environment variables.
+
+Secrets created as an environment variable must be prefixed with `LOWDEFY_SECRET_`. The remaining part of the key is the name of the variable used within the Lowdefy app.
+
+For example, if the environment variable `LOWDEFY_SECRET_API_USERNAME` is set to `super`, then `API_USERNAME` will return `super`.
+
+1. Edit the `.env` file in the path `front/`. Append the following lines:
+
+```
+LOWDEFY_SECRET_API_USERNAME=YOUR_API_USERNAME
+LOWDEFY_SECRET_API_PASSWORD=YOUR_API_PASSWORD
+```
+
+2. Edit the file `lowdefy.yaml` in the path `front/`. Insert the following code:
+
+```yml
+...
+connections:
+  - id: conn_my_api
+      ...
+      baseURL: https://dev.to/api
+      auth:
+        username:
+          _secret: API_USERNAME
+        password:
+          _secret: API_PASSWORD
+```
+
+# Protect the Python Flask server routes with HTTP Basic authentication
+
+1. Edit the `main.py` file in the path `app/`. Modify the source code as follows:
+
+```py
+...
+from flask_httpauth import HTTPBasicAuth
+from werkzeug.security import generate_password_hash, check_password_hash
+
+def create_app():
+    app = Flask(__name__)
+    auth = HTTPBasicAuth()
+
+    API_USERNAME = os.getenv('LOWDEFY_SECRET_API_USERNAME', '')
+    API_PASSWORD = os.getenv('LOWDEFY_SECRET_API_PASSWORD', '')
+
+    users = {
+        API_USERNAME: generate_password_hash(API_PASSWORD),
+    }
+
+    @auth.verify_password
+    def verify_password(username, password):
+        if username in users:
+            return check_password_hash(users.get(username), password)
+        return False
+
+    @app.route("/")
+    @auth.login_required
+    def root():
+    ...
+```
+
+# Retrieve secrets during test and run
+
+There are many methods of storing and retrieving secrets. However, in this build we will only be covering the use of environment variables.
+
+We need to ensure that the secrets are set in the environment variables on:
+
+- a Python flask server when testing and running locally
+- a Docker container server when testing and running locally
+- a Docker container server when testing and running in our CI pipeline
+- a Docker container server when testing and running in our production instance 
+
+1. Edit the `Makefile` file in the path `app/`. Insert the following code:
+
+Both the `make` rules `docker_run` and `docker_prod`, which are used to run a Docker container locally and in our production instance, respectively, accept an argument `--env-file` that specifies the environment variables file.
+
+The `make run` rule loads the environment variable file using `source` before running the Python Flask app locally.
+
+```makefile
+...
+docker_run: docker_build docker_clean
+	docker run --rm -d -p 8080:8080 --env-file=../front/.env --name=objArchiveso archiveso
+
+docker_prod: docker_stop
+	docker run --rm -d -p 8080:8080 --env-file=../front/.env --name objArchiveso dennislwm/archiveso:latest
+...
+run: 
+	set -a && source ../front/.env && set +a && FLASK_ENV=development FLASK_APP=main PYTHONPATH=./:./src/archiveso python3 -m flask run --host=0.0.0.0 --port=8080
+```
+
+2. Edit the `docker-compose.yml` file in the path `app/`. Append the following code:
+
+The `docker-compose.yml` file accepts the environment variables from the host, which in our case is the CircleCI pipeline. We have to add these key-value pairs as environment variables in our CircleCI project settings.
+
+```yml
+...
+services:
+  archiveso:
+    image: archiveso:latest
+      environment:
+        - LOWDEFY_SECRET_API_USERNAME
+        - LOWDEFY_SECRET_API_PASSWORD
+      ...
+```

--- a/front/lowdefy.yaml
+++ b/front/lowdefy.yaml
@@ -22,6 +22,11 @@ connections:
     type: AxiosHttp
     properties:
       baseURL: https://archiveso.markit.work
+      auth:
+        username:
+          _secret: API_USERNAME
+        password:
+          _secret: API_PASSWORD
 
 menus:
   - _ref: menu-top.yaml


### PR DESCRIPTION
This is part 2 of 5 parts of the build cycle.

We are using HTTP basic authentication for our Python Flask server.
This is to prevent any unauthorized persons to access our API endpoints,
which are available via a public domain.

There are many methods of storing and retrieving secrets. However, in
this build we will only be covering the use of environment variables.

We need to ensure that the secrets are set in the environment variables on:

- a Python flask server when running locally
- a Docker container server when running locally
- a Docker container server when running in our CI pipeline
- a Docker container server when running in our production instance

Next part is to build a Lowdefy page to allow user interaction.